### PR TITLE
ChoiceType - Fixed inheritence error for advanced sonata filter

### DIFF
--- a/src/Sonata/DoctrinePHPCRAdminBundle/Form/Type/Filter/ChoiceType.php
+++ b/src/Sonata/DoctrinePHPCRAdminBundle/Form/Type/Filter/ChoiceType.php
@@ -13,32 +13,14 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Form\Type\Filter;
 
-use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
-use Symfony\Component\Form\AbstractType;
+use Sonata\AdminBundle\Form\Type\Filter\ChoiceType as BaseChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ChoiceType extends AbstractType
+class ChoiceType extends BaseChoiceType
 {
     public const TYPE_CONTAINS_WORDS = 4;
-
-    private TranslatorInterface $translator;
-
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
-
-    /**
-     * NEXT_MAJOR: remove this method.
-     */
-    public function getName(): string
-    {
-        return $this->getBlockPrefix();
-    }
 
     /**
      * {@inheritdoc}
@@ -54,9 +36,9 @@ class ChoiceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $choices = [
-            $this->translator->trans('label_type_contains', [], 'SonataAdminBundle') => ContainsOperatorType::TYPE_CONTAINS,
-            $this->translator->trans('label_type_not_contains', [], 'SonataAdminBundle') => ContainsOperatorType::TYPE_NOT_CONTAINS,
-            $this->translator->trans('label_type_equals', [], 'SonataAdminBundle') => ContainsOperatorType::TYPE_EQUAL,
+            $this->translator->trans('label_type_contains', [], 'SonataAdminBundle') => self::TYPE_CONTAINS,
+            $this->translator->trans('label_type_not_contains', [], 'SonataAdminBundle') => self::TYPE_NOT_CONTAINS,
+            $this->translator->trans('label_type_equals', [], 'SonataAdminBundle') => self::TYPE_EQUAL,
             $this->translator->trans('label_type_contains_words', [], 'SonataDoctrinePHPCRAdmin') => self::TYPE_CONTAINS_WORDS,
         ];
 
@@ -65,16 +47,7 @@ class ChoiceType extends AbstractType
                 'choices' => $choices,
                 'required' => false,
             ])
-            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']));
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'field_type' => FormChoiceType::class,
-            'field_options' => [],
-            'operator_type' => ContainsOperatorType::class,
-            'operator_options' => [],
-        ]);
+	    ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
+        ;
     }
 }


### PR DESCRIPTION
**Bug**

Lorsqu'on recherche un élément dans le CMS, via les filtres des listes, une erreur se produits :
```
Undefined class constant 'TYPE_CONTAINS'
```

**Corrections**

La classe ChoiceType héritait d'AbstractType de Symfony au lieu du ChoiceType de Sonata

J'ai aussi nettoyé les méthodes surchargées inutilement